### PR TITLE
[#7] migrationを作る(操作を間違ったため再PR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@
 
 .byebug_history
 
-database.yml
+config/database.yml

--- a/db/migrate/20171109024028_create_users.rb
+++ b/db/migrate/20171109024028_create_users.rb
@@ -5,7 +5,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
       t.string :name # userの名前
       t.boolean :admin # 管理者か非管理者かの判断
       t.string :password # userのパスワード
-      t.string :sait #
+      t.string :sait # userの興味のある分野
       t.string :position_ids # 役職クラスのID
       t.string :qualification_ids # 資格クラスのID
       t.string :project_ids # 案件クラスのID


### PR DESCRIPTION
## ISSUE

https://github.com/s-inagawa/r_seem/issues/7

## 概要

指摘された点を修正

## 動作確認

 - [x] カラムを指定しmigrationファイルを作成
 - [x] gitignore にconfig/database.ymlを追加


## 補足事項
操作を誤り、merge PRボタンを押してしまったためPRし直します。


create_users.rb以外のmigraitonファイルにつきましては以下を参照くださいますよう、お願いいたします。

https://github.com/s-inagawa/r_seem/commit/bef0187b2aee73a66d0f400c197710b33e02edd4
 
